### PR TITLE
feat: 커리큘럼 전체 리스트를 가져오는 API 추가

### DIFF
--- a/src/main/java/com/lubycon/curriculum/curriculum/api/CurriculumApi.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/api/CurriculumApi.java
@@ -1,0 +1,23 @@
+package com.lubycon.curriculum.curriculum.api;
+
+import com.lubycon.curriculum.curriculum.dto.CurriculumResponse;
+import com.lubycon.curriculum.curriculum.service.CurriculumService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class CurriculumApi {
+
+  private final CurriculumService curriculumService;
+
+  @GetMapping("/curriculums")
+  public ResponseEntity<List<CurriculumResponse>> getAllCurriculums() {
+
+    return ResponseEntity.ok()
+        .body(curriculumService.getCurriculums());
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/CurriculumResponse.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/CurriculumResponse.java
@@ -1,0 +1,28 @@
+package com.lubycon.curriculum.curriculum.dto;
+
+import com.lubycon.curriculum.curriculum.domain.Curriculum;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Getter
+public class CurriculumResponse {
+
+  private final long id;
+
+  @NotNull
+  private final String title;
+
+  @Nullable
+  private final String description;
+
+  @NotNull
+  private final String thumbnail;
+
+  public CurriculumResponse(final Curriculum curriculum) {
+    this.id = curriculum.getId();
+    this.title = curriculum.getTitle();
+    this.description = curriculum.getDescription();
+    this.thumbnail = curriculum.getThumbnail();
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
@@ -1,0 +1,17 @@
+package com.lubycon.curriculum.curriculum.service;
+
+import com.lubycon.curriculum.curriculum.dto.CurriculumResponse;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CurriculumService {
+
+  public List<CurriculumResponse> getCurriculums() {
+    return Collections.EMPTY_LIST;
+  }
+
+}

--- a/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -14,6 +15,7 @@ public class CurriculumService {
 
   private final CurriculumRepository curriculumRepository;
 
+  @Transactional(readOnly = true)
   public List<CurriculumResponse> getCurriculums() {
     return findAll()
         .stream()

--- a/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
@@ -1,8 +1,10 @@
 package com.lubycon.curriculum.curriculum.service;
 
+import com.lubycon.curriculum.curriculum.domain.Curriculum;
 import com.lubycon.curriculum.curriculum.dto.CurriculumResponse;
-import java.util.Collections;
+import com.lubycon.curriculum.curriculum.repository.CurriculumRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,8 +12,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class CurriculumService {
 
+  private final CurriculumRepository curriculumRepository;
+
   public List<CurriculumResponse> getCurriculums() {
-    return Collections.EMPTY_LIST;
+    return findAll()
+        .stream()
+        .map(CurriculumResponse::new)
+        .collect(Collectors.toList());
+  }
+
+  private List<Curriculum> findAll() {
+    return curriculumRepository.findAll();
   }
 
 }

--- a/src/test/java/com/lubycon/curriculum/base/ApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/base/ApiTest.java
@@ -12,9 +12,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+@Transactional
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc

--- a/src/test/java/com/lubycon/curriculum/curriculum/api/CurriculumApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/curriculum/api/CurriculumApiTest.java
@@ -1,0 +1,35 @@
+package com.lubycon.curriculum.curriculum.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.lubycon.curriculum.base.ApiTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.ResultActions;
+
+class CurriculumApiTest extends ApiTest {
+
+  @Sql("/make-four-curriculums-only.sql")
+  @DisplayName("전체 커리큘럼 리스트를 가져온다.")
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 2, 3})
+  public void getCurriculumTest(final int index) throws Exception {
+    // given
+    final String url = "/curriculums";
+
+    // when
+    final ResultActions resultActions = mockMvc.perform(get(url));
+
+    // then
+    resultActions
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[%d].title", index).value(index + "번 커리큘럼의 제목"))
+        .andExpect(jsonPath("$[%d].description", index).value(index + "번 커리큘럼의 설명"))
+        .andExpect(jsonPath("$[%d].thumbnail", index).value(index + "번 커리큘럼의 썸네일"));
+  }
+
+}

--- a/src/test/java/com/lubycon/curriculum/curriculum/service/CurriculumServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/curriculum/service/CurriculumServiceTest.java
@@ -1,0 +1,37 @@
+package com.lubycon.curriculum.curriculum.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lubycon.curriculum.curriculum.dto.CurriculumResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class CurriculumServiceTest {
+
+  @Autowired
+  CurriculumService curriculumService;
+
+  @Sql("/make-four-curriculums-only.sql")
+  @DisplayName("커리큘럼 리스트를 가져온다.")
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 2, 3})
+  public void getCurriculumsTest(final int index) {
+    // when
+    final List<CurriculumResponse> curriculums = curriculumService.getCurriculums();
+
+    // then
+    assertThat(curriculums.size()).isEqualTo(4);
+    assertThat(curriculums.get(index).getTitle()).isEqualTo(index + "번 커리큘럼의 제목");
+    assertThat(curriculums.get(index).getDescription()).isEqualTo(index + "번 커리큘럼의 설명");
+    assertThat(curriculums.get(index).getThumbnail()).isEqualTo(index + "번 커리큘럼의 썸네일");
+  }
+
+}

--- a/src/test/resources/make-four-curriculums-only.sql
+++ b/src/test/resources/make-four-curriculums-only.sql
@@ -1,0 +1,4 @@
+INSERT INTO curriculum (id, title, description, thumbnail) VALUES (0, '0번 커리큘럼의 제목', '0번 커리큘럼의 설명', '0번 커리큘럼의 썸네일')
+INSERT INTO curriculum (id, title, description, thumbnail) VALUES (1, '1번 커리큘럼의 제목', '1번 커리큘럼의 설명', '1번 커리큘럼의 썸네일')
+INSERT INTO curriculum (id, title, description, thumbnail) VALUES (2, '2번 커리큘럼의 제목', '2번 커리큘럼의 설명', '2번 커리큘럼의 썸네일')
+INSERT INTO curriculum (id, title, description, thumbnail) VALUES (3, '3번 커리큘럼의 제목', '3번 커리큘럼의 설명', '3번 커리큘럼의 썸네일')


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->
[API 정의서](https://app.swaggerhub.com/apis/sun15/curriculum/1.0.0#free)를 바탕으로 작성한 API로, 커리큘럼의 전체 리스트를 가져오는 API입니다.

## 참고 사항
resolved #8 
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
