### PR TITLE
feat: 특정 커리큘럼의 섹션 전체 리스트를 가져오는 API 추가

### DIFF
--- a/src/main/java/com/lubycon/curriculum/curriculum/domain/Curriculum.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/domain/Curriculum.java
@@ -12,6 +12,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,11 +41,12 @@ public class Curriculum extends BaseTimeEntity {
   private IntroSection introSection;
 
   @OneToMany(mappedBy = "curriculum", fetch = FetchType.LAZY)
+  @OrderBy("order asc")
   private List<Section> sections;
 
   @Builder
-  public Curriculum(String title, String description, String thumbnail,
-      List<Section> sections) {
+  public Curriculum(final String title, final String description, final String thumbnail,
+      final List<Section> sections) {
     this.title = title;
     this.description = description;
     this.thumbnail = thumbnail;

--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/CurriculumInfoResponse.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/CurriculumInfoResponse.java
@@ -1,0 +1,18 @@
+package com.lubycon.curriculum.curriculum.dto;
+
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+public class CurriculumInfoResponse {
+
+  private final long id;
+
+  @NotNull
+  private final String title;
+
+  public CurriculumInfoResponse(final long id, @NotNull final String title) {
+    this.id = id;
+    this.title = title;
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/CurriculumSectionsResponse.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/CurriculumSectionsResponse.java
@@ -1,0 +1,30 @@
+package com.lubycon.curriculum.curriculum.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+public class CurriculumSectionsResponse {
+
+  @NotNull
+  private final CurriculumInfoResponse curriculum;
+
+  @NotNull
+  private final IntroResponse intro;
+
+  @NotNull
+  private final List<SectionTitlesResponse> sections;
+
+
+  @Builder
+  public CurriculumSectionsResponse(
+      @NotNull final CurriculumInfoResponse curriculum,
+      @NotNull final IntroResponse intro,
+      @NotNull final List<SectionTitlesResponse> sections) {
+    this.curriculum = curriculum;
+    this.intro = intro;
+    this.sections = sections;
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/CurriculumSectionsResponse.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/CurriculumSectionsResponse.java
@@ -1,6 +1,10 @@
 package com.lubycon.curriculum.curriculum.dto;
 
+import com.lubycon.curriculum.curriculum.domain.Curriculum;
+import com.lubycon.curriculum.section.domain.Section;
+import com.lubycon.curriculum.section.model.IntroDescription;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
@@ -26,5 +30,18 @@ public class CurriculumSectionsResponse {
     this.curriculum = curriculum;
     this.intro = intro;
     this.sections = sections;
+  }
+
+  public static CurriculumSectionsResponse toResponse(final Curriculum curriculum) {
+    final IntroDescription introDescription = curriculum.getIntroSection().getDescription();
+    final List<Section> sections = curriculum.getSections();
+
+    return CurriculumSectionsResponse.builder()
+        .intro(new IntroResponse(introDescription))
+        .curriculum(new CurriculumInfoResponse(curriculum.getId(), curriculum.getTitle()))
+        .sections(sections.stream()
+            .map(SectionTitlesResponse::new)
+            .collect(Collectors.toList()))
+        .build();
   }
 }

--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/IntroResponse.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/IntroResponse.java
@@ -1,5 +1,6 @@
 package com.lubycon.curriculum.curriculum.dto;
 
+import com.lubycon.curriculum.section.model.IntroDescription;
 import lombok.Getter;
 import org.jetbrains.annotations.Nullable;
 
@@ -12,9 +13,10 @@ public class IntroResponse {
   @Nullable
   private final String description;
 
-  public IntroResponse(@Nullable final String summary,
-      @Nullable final String description) {
-    this.summary = summary;
-    this.description = description;
+  public IntroResponse(final IntroDescription intro) {
+    this.summary = intro.getSummary();
+    this.description = intro.getDescription();
   }
+
+
 }

--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/IntroResponse.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/IntroResponse.java
@@ -1,0 +1,20 @@
+package com.lubycon.curriculum.curriculum.dto;
+
+import lombok.Getter;
+import org.jetbrains.annotations.Nullable;
+
+@Getter
+public class IntroResponse {
+
+  @Nullable
+  private final String summary;
+
+  @Nullable
+  private final String description;
+
+  public IntroResponse(@Nullable final String summary,
+      @Nullable final String description) {
+    this.summary = summary;
+    this.description = description;
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/SectionTitlesResponse.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/SectionTitlesResponse.java
@@ -1,5 +1,6 @@
 package com.lubycon.curriculum.curriculum.dto;
 
+import com.lubycon.curriculum.section.domain.Section;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,9 +14,9 @@ public class SectionTitlesResponse {
 
   private final int order;
 
-  public SectionTitlesResponse(final long id, @NotNull final String title, final int order) {
-    this.id = id;
-    this.title = title;
-    this.order = order;
+  public SectionTitlesResponse(final Section section) {
+    this.id = section.getId();
+    this.title = section.getTitle();
+    this.order = section.getOrder();
   }
 }

--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/SectionTitlesResponse.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/SectionTitlesResponse.java
@@ -1,0 +1,21 @@
+package com.lubycon.curriculum.curriculum.dto;
+
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+
+@Getter
+public class SectionTitlesResponse {
+
+  private final long id;
+
+  @NotNull
+  private final String title;
+
+  private final int order;
+
+  public SectionTitlesResponse(final long id, @NotNull final String title, final int order) {
+    this.id = id;
+    this.title = title;
+    this.order = order;
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
@@ -2,6 +2,7 @@ package com.lubycon.curriculum.curriculum.service;
 
 import com.lubycon.curriculum.curriculum.domain.Curriculum;
 import com.lubycon.curriculum.curriculum.dto.CurriculumResponse;
+import com.lubycon.curriculum.curriculum.dto.CurriculumSectionsResponse;
 import com.lubycon.curriculum.curriculum.repository.CurriculumRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,8 +24,20 @@ public class CurriculumService {
         .collect(Collectors.toList());
   }
 
+  @Transactional(readOnly = true)
+  public CurriculumSectionsResponse getCurriculumSections(final long curriculumId) {
+    final Curriculum curriculum = findById(curriculumId);
+    return CurriculumSectionsResponse.toResponse(curriculum);
+  }
+
+
   private List<Curriculum> findAll() {
     return curriculumRepository.findAll();
+  }
+
+  private Curriculum findById(final long id) {
+    return curriculumRepository.findById(id)
+        .orElseThrow(RuntimeException::new); // FIXME: 예외 바꾸기
   }
 
 }

--- a/src/main/java/com/lubycon/curriculum/section/api/SectionApi.java
+++ b/src/main/java/com/lubycon/curriculum/section/api/SectionApi.java
@@ -1,5 +1,7 @@
 package com.lubycon.curriculum.section.api;
 
+import com.lubycon.curriculum.curriculum.dto.CurriculumSectionsResponse;
+import com.lubycon.curriculum.curriculum.service.CurriculumService;
 import com.lubycon.curriculum.section.dto.SectionResponse;
 import com.lubycon.curriculum.section.service.SectionService;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SectionApi {
 
   private final SectionService sectionService;
+  private final CurriculumService curriculumService;
 
   @GetMapping("/curriculums/{curriculumId}/sections/{sectionId}")
   public ResponseEntity<SectionResponse> getSection(
@@ -21,4 +24,14 @@ public class SectionApi {
     return ResponseEntity.ok()
         .body(sectionService.findSection(curriculumId, sectionId));
   }
+
+  @GetMapping("/curriculums/{curriculumId}/sections")
+  public ResponseEntity<CurriculumSectionsResponse> getAllSections(
+      @PathVariable final long curriculumId) {
+
+    return ResponseEntity.ok()
+        .body(curriculumService.getCurriculumSections(curriculumId));
+  }
+
+
 }

--- a/src/test/java/com/lubycon/curriculum/curriculum/service/CurriculumServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/curriculum/service/CurriculumServiceTest.java
@@ -2,9 +2,14 @@ package com.lubycon.curriculum.curriculum.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.lubycon.curriculum.curriculum.dto.CurriculumInfoResponse;
 import com.lubycon.curriculum.curriculum.dto.CurriculumResponse;
+import com.lubycon.curriculum.curriculum.dto.CurriculumSectionsResponse;
+import com.lubycon.curriculum.curriculum.dto.IntroResponse;
+import com.lubycon.curriculum.curriculum.dto.SectionTitlesResponse;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +37,27 @@ class CurriculumServiceTest {
     assertThat(curriculums.get(index).getTitle()).isEqualTo(index + "번 커리큘럼의 제목");
     assertThat(curriculums.get(index).getDescription()).isEqualTo(index + "번 커리큘럼의 설명");
     assertThat(curriculums.get(index).getThumbnail()).isEqualTo(index + "번 커리큘럼의 썸네일");
+  }
+
+  @Sql("/make-curriculum.sql")
+  @DisplayName("특정 커리큘럼의 정보를 가져온다.")
+  @Test
+  public void getCurriculumsTest() {
+    // when
+    final CurriculumSectionsResponse response = curriculumService.getCurriculumSections(1);
+
+    // then
+    final CurriculumInfoResponse curriculum = response.getCurriculum();
+    assertThat(curriculum.getTitle()).isEqualTo("1번 커리큘럼의 제목");
+
+    final IntroResponse intro = response.getIntro();
+    assertThat(intro.getSummary()).isEqualTo("1번 커리큘럼의 핵심 설명");
+    assertThat(intro.getDescription()).isEqualTo("1번 커리큘럼의 설명");
+
+    final SectionTitlesResponse section = response.getSections().get(2);
+    assertThat(section.getOrder()).isEqualTo(2);
+    assertThat(section.getId()).isEqualTo(300);
+    assertThat(section.getTitle()).isEqualTo("1번 커리큘럼의 섹션3");
   }
 
 }

--- a/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
@@ -33,4 +33,25 @@ class SectionApiTest extends ApiTest {
         .andExpect(jsonPath("$.prevSection.title").value("1번 커리큘럼의 섹션2"));
   }
 
+  @Sql("/make-curriculum.sql")
+  @DisplayName("특정 커리큘럼의 섹션들을 가져온다.")
+  @Test
+  public void getAllSections() throws Exception {
+    // given
+    final String url = "/curriculums/{curriculumId}/sections";
+
+    // when
+    final ResultActions resultActions = mockMvc.perform(get(url, 1));
+
+    // then
+    resultActions
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.curriculum.title").value("1번 커리큘럼의 제목"))
+        .andExpect(jsonPath("$.intro.summary").value("1번 커리큘럼의 핵심 설명"))
+        .andExpect(jsonPath("$.intro.description").value("1번 커리큘럼의 설명"))
+        .andExpect(jsonPath("$.sections[2].order").value(2))
+        .andExpect(jsonPath("$.sections[2].id").value(300))
+        .andExpect(jsonPath("$.sections[2].title").value("1번 커리큘럼의 섹션3"));
+  }
+
 }


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->
[API 정의서](https://app.swaggerhub.com/apis/sun15/curriculum/1.0.0#free)를 바탕으로 작성한 API로, 특정 커리큘럼의 전체 섹션 리스트를 가져오는 API입니다.

## 참고 사항
resolved #10 
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
