### PR TITLE
feat: 예외 구조, 처리 로직 추가

### DIFF
--- a/src/main/java/com/lubycon/curriculum/base/error/ErrorCode.java
+++ b/src/main/java/com/lubycon/curriculum/base/error/ErrorCode.java
@@ -10,9 +10,9 @@ public enum ErrorCode {
   METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "Invalid Input Value"),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "Internal Server Error"),
   INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "Invalid Type Value"),
-  ENTITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "C005", "Entity Not Found"),
+  ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "Entity Not Found"),
   FAIL_ENUM_BINDING(HttpStatus.BAD_REQUEST, "C006", "Fail Enum Binding");
-  
+
   private final String code;
   private final String message;
   private final HttpStatus status;

--- a/src/main/java/com/lubycon/curriculum/base/error/ErrorResponse.java
+++ b/src/main/java/com/lubycon/curriculum/base/error/ErrorResponse.java
@@ -30,6 +30,11 @@ public class ErrorResponse {
     this.errors = new ArrayList<>();
   }
 
+  public ErrorResponse(final ErrorCode code, final String message) {
+    this.message = message;
+    this.code = code.getCode();
+    this.errors = new ArrayList<>();
+  }
 
   public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
     return new ErrorResponse(code, FieldError.of(bindingResult));
@@ -39,11 +44,15 @@ public class ErrorResponse {
     return new ErrorResponse(code);
   }
 
+  public static ErrorResponse of(final ErrorCode code, final String message) {
+    return new ErrorResponse(code, message);
+  }
+
   public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
     return new ErrorResponse(code, errors);
   }
 
-  public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+  public static ErrorResponse of(final MethodArgumentTypeMismatchException e) {
     final String value = e.getValue() == null ? "" : e.getValue().toString();
     final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError
         .of(e.getName(), value, e.getErrorCode());
@@ -65,7 +74,7 @@ public class ErrorResponse {
     }
 
     public static List<FieldError> of(final String field, final String value, final String reason) {
-      List<FieldError> fieldErrors = new ArrayList<>();
+      final List<FieldError> fieldErrors = new ArrayList<>();
       fieldErrors.add(new FieldError(field, value, reason));
       return fieldErrors;
     }

--- a/src/main/java/com/lubycon/curriculum/base/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lubycon/curriculum/base/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.lubycon.curriculum.base.error;
 
+import com.lubycon.curriculum.base.error.exception.BusinessException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -52,6 +53,13 @@ public class GlobalExceptionHandler {
   protected ResponseEntity<ErrorResponse> handleException(final Exception e) {
     final ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
     final ErrorResponse response = ErrorResponse.of(errorCode);
+    return new ResponseEntity<>(response, errorCode.getStatus());
+  }
+
+  @ExceptionHandler(BusinessException.class)
+  protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+    final ErrorCode errorCode = e.getErrorCode();
+    final ErrorResponse response = ErrorResponse.of(errorCode, e.getMessage());
     return new ResponseEntity<>(response, errorCode.getStatus());
   }
 }

--- a/src/main/java/com/lubycon/curriculum/curriculum/exception/CurriculumNotFoundException.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/exception/CurriculumNotFoundException.java
@@ -1,0 +1,10 @@
+package com.lubycon.curriculum.curriculum.exception;
+
+import com.lubycon.curriculum.base.error.exception.EntityNotFoundException;
+
+public class CurriculumNotFoundException extends EntityNotFoundException {
+
+  public CurriculumNotFoundException(final String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/service/CurriculumService.java
@@ -3,6 +3,7 @@ package com.lubycon.curriculum.curriculum.service;
 import com.lubycon.curriculum.curriculum.domain.Curriculum;
 import com.lubycon.curriculum.curriculum.dto.CurriculumResponse;
 import com.lubycon.curriculum.curriculum.dto.CurriculumSectionsResponse;
+import com.lubycon.curriculum.curriculum.exception.CurriculumNotFoundException;
 import com.lubycon.curriculum.curriculum.repository.CurriculumRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,7 +38,7 @@ public class CurriculumService {
 
   private Curriculum findById(final long id) {
     return curriculumRepository.findById(id)
-        .orElseThrow(RuntimeException::new); // FIXME: 예외 바꾸기
+        .orElseThrow(() -> new CurriculumNotFoundException(id + "에 해당하는 커리큘럼이 없습니다."));
   }
 
 }

--- a/src/main/java/com/lubycon/curriculum/section/exception/SectionNotFoundException.java
+++ b/src/main/java/com/lubycon/curriculum/section/exception/SectionNotFoundException.java
@@ -1,0 +1,10 @@
+package com.lubycon.curriculum.section.exception;
+
+import com.lubycon.curriculum.base.error.exception.EntityNotFoundException;
+
+public class SectionNotFoundException extends EntityNotFoundException {
+
+  public SectionNotFoundException(final String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/section/service/SectionService.java
+++ b/src/main/java/com/lubycon/curriculum/section/service/SectionService.java
@@ -4,6 +4,7 @@ import com.lubycon.curriculum.section.domain.Section;
 import com.lubycon.curriculum.section.dto.NextSectionResponse;
 import com.lubycon.curriculum.section.dto.PrevSectionResponse;
 import com.lubycon.curriculum.section.dto.SectionResponse;
+import com.lubycon.curriculum.section.exception.SectionNotFoundException;
 import com.lubycon.curriculum.section.repository.SectionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,7 @@ public class SectionService {
 
   private Section findById(final long curriculumId, final long sectionId) {
     return sectionRepository.findByCurriculumIdAndId(curriculumId, sectionId)
-        .orElseThrow(RuntimeException::new); // FIXME: 예외 바꾸기
+        .orElseThrow(() -> new SectionNotFoundException(sectionId + "에 해당하는 섹션이 없습니다."));
   }
 
   private NextSectionResponse findNextSection(final long curriculumId, final int order) {

--- a/src/test/java/com/lubycon/curriculum/curriculum/service/CurriculumServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/curriculum/service/CurriculumServiceTest.java
@@ -1,12 +1,14 @@
 package com.lubycon.curriculum.curriculum.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.lubycon.curriculum.curriculum.dto.CurriculumInfoResponse;
 import com.lubycon.curriculum.curriculum.dto.CurriculumResponse;
 import com.lubycon.curriculum.curriculum.dto.CurriculumSectionsResponse;
 import com.lubycon.curriculum.curriculum.dto.IntroResponse;
 import com.lubycon.curriculum.curriculum.dto.SectionTitlesResponse;
+import com.lubycon.curriculum.curriculum.exception.CurriculumNotFoundException;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,6 +60,19 @@ class CurriculumServiceTest {
     assertThat(section.getOrder()).isEqualTo(2);
     assertThat(section.getId()).isEqualTo(300);
     assertThat(section.getTitle()).isEqualTo("1번 커리큘럼의 섹션3");
+  }
+
+  @Sql("/make-curriculum.sql")
+  @DisplayName("커리큘럼이 없으면 예외가 발생한다.")
+  @Test
+  public void curriculumNotFoundTest() {
+    // given
+    final long notExistId = 1222;
+
+    // when
+    assertThatThrownBy(() -> curriculumService.getCurriculumSections(notExistId))
+        .isInstanceOf(CurriculumNotFoundException.class)
+        .hasMessageContaining(notExistId + "에 해당하는 커리큘럼이 없습니다."); // then
   }
 
 }

--- a/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
@@ -54,4 +54,22 @@ class SectionApiTest extends ApiTest {
         .andExpect(jsonPath("$.sections[2].title").value("1번 커리큘럼의 섹션3"));
   }
 
+  @Sql("/make-curriculum.sql")
+  @DisplayName("특정 커리큘럼이 없다면 404가 발생한다.")
+  @Test
+  public void notFoundCurriculumTest() throws Exception {
+    // given
+    final String url = "/curriculums/{curriculumId}/sections";
+    final long notExistId = 1222;
+
+    // when
+    final ResultActions resultActions = mockMvc.perform(get(url, notExistId));
+
+    // then
+    resultActions
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value(notExistId + "에 해당하는 커리큘럼이 없습니다."))
+        .andExpect(jsonPath("$.code").value("C005"));
+  }
+
 }

--- a/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
@@ -72,4 +72,22 @@ class SectionApiTest extends ApiTest {
         .andExpect(jsonPath("$.code").value("C005"));
   }
 
+  @Sql("/make-curriculum.sql")
+  @DisplayName("특정 커리큘럼이 없다면 404가 발생한다.")
+  @Test
+  public void notFoundSectionTest() throws Exception {
+    // given
+    final String url = "/curriculums/{curriculumId}/sections/{sectionId}";
+    final long notExistId = 1222;
+
+    // when
+    final ResultActions resultActions = mockMvc.perform(get(url, 1, notExistId));
+
+    // then
+    resultActions
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message").value(notExistId + "에 해당하는 섹션이 없습니다."))
+        .andExpect(jsonPath("$.code").value("C005"));
+  }
+
 }

--- a/src/test/java/com/lubycon/curriculum/section/service/SectionServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/service/SectionServiceTest.java
@@ -1,8 +1,10 @@
 package com.lubycon.curriculum.section.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import com.lubycon.curriculum.section.dto.SectionResponse;
+import com.lubycon.curriculum.section.exception.SectionNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,4 +34,18 @@ class SectionServiceTest {
     assertThat(findSection.getPrevSection().getTitle()).isEqualTo("1번 커리큘럼의 섹션2");
     assertThat(findSection.getNextSection().getTitle()).isEqualTo("1번 커리큘럼의 섹션4");
   }
+
+  @Sql("/make-curriculum.sql")
+  @DisplayName("섹션이 없으면 예외가 발생한다.")
+  @Test
+  public void curriculumNotFoundTest() {
+    // given
+    final long notExistId = 1222;
+
+    // when
+    assertThatThrownBy(() -> sectionService.findSection(1, notExistId))
+        .isInstanceOf(SectionNotFoundException.class)
+        .hasMessageContaining(notExistId + "에 해당하는 섹션이 없습니다."); // then
+  }
+
 }


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->
API 리뷰를 거친 [API 정의서](https://app.swaggerhub.com/apis/sun15/curriculum/1.0.0#free)를 바탕으로 예외 (SectionNotFoundException, CurriculumNotFoundException)와 예외 처리를 추가했습니다.
![CurriculumNotFoundException](https://user-images.githubusercontent.com/42836576/117039989-5592d680-ad44-11eb-929a-690cefabd95a.png)


## 특별히 봐줬으면 하는 부분
더 좋은 계층 구조가 있다면 제안 부탁드립니다! 🙇‍♀️
<!-- 셀프 코멘트도 달아주세요! -->

## 참고 사항
resolved #23 
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
