### PR TITLE
예외 발생 시 로그 추가 및 기존 url 컨트롤러에 추가

### DIFF
--- a/src/main/java/com/lubycon/curriculum/base/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lubycon/curriculum/base/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.lubycon.curriculum.base.error;
 
 import com.lubycon.curriculum.base.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Slf4j
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -16,6 +18,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException.class)
   protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(
       final MethodArgumentNotValidException e) {
+    log.error("MethMethodArgumentNotValidException", e);
     final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
     final ErrorResponse response = ErrorResponse
         .of(errorCode, e.getBindingResult());
@@ -25,6 +28,7 @@ public class GlobalExceptionHandler {
   // @ModelAttribut으로 binding error 발생시 BindException 발생
   @ExceptionHandler(BindException.class)
   protected ResponseEntity<ErrorResponse> handleBindException(final BindException e) {
+    log.error("BindException", e);
     final ErrorCode errorCode = ErrorCode.INVALID_INPUT_VALUE;
     final ErrorResponse response = ErrorResponse
         .of(errorCode, e.getBindingResult());
@@ -35,6 +39,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(MethodArgumentTypeMismatchException.class)
   protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
       final MethodArgumentTypeMismatchException e) {
+    log.error("MethodArgumentTypeMismatchException", e);
     final ErrorCode errorCode = ErrorCode.FAIL_ENUM_BINDING;
     final ErrorResponse response = ErrorResponse.of(e);
     return new ResponseEntity<>(response, errorCode.getStatus());
@@ -44,6 +49,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
   protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
       final HttpRequestMethodNotSupportedException e) {
+    log.error("HttpRequestMethodNotSupportedException", e);
     final ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
     final ErrorResponse response = ErrorResponse.of(errorCode);
     return new ResponseEntity<>(response, errorCode.getStatus());
@@ -51,6 +57,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(Exception.class)
   protected ResponseEntity<ErrorResponse> handleException(final Exception e) {
+    log.error("Exception", e);
     final ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
     final ErrorResponse response = ErrorResponse.of(errorCode);
     return new ResponseEntity<>(response, errorCode.getStatus());
@@ -58,6 +65,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(BusinessException.class)
   protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+    log.error("BusinessException", e);
     final ErrorCode errorCode = e.getErrorCode();
     final ErrorResponse response = ErrorResponse.of(errorCode, e.getMessage());
     return new ResponseEntity<>(response, errorCode.getStatus());

--- a/src/main/java/com/lubycon/curriculum/curriculum/api/CurriculumApi.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/api/CurriculumApi.java
@@ -14,7 +14,7 @@ public class CurriculumApi {
 
   private final CurriculumService curriculumService;
 
-  @GetMapping("/v1/curriculums")
+  @GetMapping(value = {"/v1/curriculums", "/curriculums"})
   public ResponseEntity<List<CurriculumResponse>> getAllCurriculums() {
 
     return ResponseEntity.ok()

--- a/src/main/java/com/lubycon/curriculum/section/api/SectionApi.java
+++ b/src/main/java/com/lubycon/curriculum/section/api/SectionApi.java
@@ -17,7 +17,8 @@ public class SectionApi {
   private final SectionService sectionService;
   private final CurriculumService curriculumService;
 
-  @GetMapping("/v1/curriculums/{curriculumId}/sections/{sectionId}")
+  @GetMapping(value = {"/v1/curriculums/{curriculumId}/sections/{sectionId}",
+      "curriculums/{curriculumId}/sections/{sectionId}"})
   public ResponseEntity<SectionResponse> getSection(
       @PathVariable final long curriculumId, @PathVariable final long sectionId) {
 
@@ -25,7 +26,8 @@ public class SectionApi {
         .body(sectionService.findSection(curriculumId, sectionId));
   }
 
-  @GetMapping("/v1/curriculums/{curriculumId}/sections")
+  @GetMapping(value = {"/v1/curriculums/{curriculumId}/sections",
+      "/curriculums/{curriculumId}/sections"})
   public ResponseEntity<CurriculumSectionsResponse> getAllSections(
       @PathVariable final long curriculumId) {
 


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

- 예외사항 발생 시 예외 발생지점 추적을 위해 로그에 예외 발생 부분 출력
- url에 `v1`을 추가하기로 결정하였으나, 프론트와 서버 배포 지점을 정확히 맞추기 어렵기 때문에 기존 url도 컨트롤러에 추가 (추후에 `v1`이 달려있지 않은 url은 제거 예정)
