### PR TITLE
feat: Typeform 이메일 API와 연동

### DIFF
--- a/src/main/java/com/lubycon/curriculum/CurriculumApplication.java
+++ b/src/main/java/com/lubycon/curriculum/CurriculumApplication.java
@@ -2,11 +2,13 @@ package com.lubycon.curriculum;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 
+@ServletComponentScan
 @SpringBootApplication
 public class CurriculumApplication {
 
-  public static void main(String[] args) {
+  public static void main(final String[] args) {
     SpringApplication.run(CurriculumApplication.class, args);
   }
 

--- a/src/main/java/com/lubycon/curriculum/base/error/ErrorCode.java
+++ b/src/main/java/com/lubycon/curriculum/base/error/ErrorCode.java
@@ -11,7 +11,11 @@ public enum ErrorCode {
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "Internal Server Error"),
   INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C004", "Invalid Type Value"),
   ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C005", "Entity Not Found"),
-  FAIL_ENUM_BINDING(HttpStatus.BAD_REQUEST, "C006", "Fail Enum Binding");
+  FAIL_ENUM_BINDING(HttpStatus.BAD_REQUEST, "C006", "Fail Enum Binding"),
+
+  // Subscribe
+  TYPEFORM_SECRET_NOT_EQUALS(HttpStatus.UNAUTHORIZED, "S001", "Typeform secret not equals : ");
+
 
   private final String code;
   private final String message;

--- a/src/main/java/com/lubycon/curriculum/subscribe/api/SubScribeApi.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/api/SubScribeApi.java
@@ -1,0 +1,26 @@
+package com.lubycon.curriculum.subscribe.api;
+
+import com.lubycon.curriculum.subscribe.dto.TypeformSubscribeRequest;
+import com.lubycon.curriculum.subscribe.service.SubscribeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class SubScribeApi {
+
+  private final SubscribeService subscribeService;
+
+  @PostMapping("/subscribe/typeform")
+  public ResponseEntity<Object> typeformSubscribe(
+      @RequestBody final TypeformSubscribeRequest request) {
+
+    subscribeService.subscribe(request.getEmail());
+
+    return ResponseEntity.ok()
+        .build();
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/domain/Email.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/domain/Email.java
@@ -19,11 +19,10 @@ public class Email {
   @Column(name = "id", updatable = false)
   private Long id;
 
-  @Column(name = "email", nullable = false)
+  @Column(name = "email", nullable = false, unique = true)
   private String email;
 
-  public Email(final Long id, final String email) {
-    this.id = id;
+  public Email(final String email) {
     this.email = email;
   }
 }

--- a/src/main/java/com/lubycon/curriculum/subscribe/domain/Email.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/domain/Email.java
@@ -1,0 +1,29 @@
+package com.lubycon.curriculum.subscribe.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class Email {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id", updatable = false)
+  private Long id;
+
+  @Column(name = "email", nullable = false)
+  private String email;
+
+  public Email(final Long id, final String email) {
+    this.id = id;
+    this.email = email;
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/dto/EmailDto.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/dto/EmailDto.java
@@ -1,0 +1,13 @@
+package com.lubycon.curriculum.subscribe.dto;
+
+import lombok.Getter;
+
+@Getter
+public class EmailDto {
+
+  private final String email;
+
+  public EmailDto(final String email) {
+    this.email = email;
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/dto/TypeformAnswer.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/dto/TypeformAnswer.java
@@ -1,0 +1,18 @@
+package com.lubycon.curriculum.subscribe.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+@Setter
+@Getter
+public class TypeformAnswer {
+
+  @NotNull
+  private String type;
+
+  @Nullable
+  private String email;
+
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/dto/TypeformResponse.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/dto/TypeformResponse.java
@@ -1,0 +1,25 @@
+package com.lubycon.curriculum.subscribe.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.jetbrains.annotations.NotNull;
+
+@Setter
+@Getter
+public class TypeformResponse {
+
+  @NotNull
+  private List<TypeformAnswer> answers;
+
+  public String getEmailFromResponse() {
+    for (final TypeformAnswer answer : answers) {
+      if (answer.getType().equals("email")) {
+        return answer.getEmail();
+      }
+    }
+
+    return "";
+  }
+
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/dto/TypeformSubscribeRequest.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/dto/TypeformSubscribeRequest.java
@@ -1,0 +1,17 @@
+package com.lubycon.curriculum.subscribe.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class TypeformSubscribeRequest {
+
+  @JsonProperty("form_response")
+  private TypeformResponse formResponse;
+
+  public String getEmail() {
+    return formResponse.getEmailFromResponse();
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/exception/TypeFormSecretNotEquals.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/exception/TypeFormSecretNotEquals.java
@@ -1,0 +1,12 @@
+package com.lubycon.curriculum.subscribe.exception;
+
+import com.lubycon.curriculum.base.error.ErrorCode;
+import com.lubycon.curriculum.base.error.exception.BusinessException;
+
+public class TypeFormSecretNotEquals extends BusinessException {
+
+  public TypeFormSecretNotEquals(final String input) {
+    super(ErrorCode.TYPEFORM_SECRET_NOT_EQUALS.getMessage() + input,
+        ErrorCode.TYPEFORM_SECRET_NOT_EQUALS);
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/filter/TypeformFilter.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/filter/TypeformFilter.java
@@ -17,7 +17,11 @@ import org.springframework.beans.factory.annotation.Value;
 public class TypeformFilter implements Filter {
 
   @Value("${typeform.secret}")
-  private String secretKey;
+  private final String secretKey;
+
+  public TypeformFilter(final String secretKey) {
+    this.secretKey = secretKey;
+  }
 
   @Override
   public void doFilter(

--- a/src/main/java/com/lubycon/curriculum/subscribe/filter/TypeformFilter.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/filter/TypeformFilter.java
@@ -1,0 +1,36 @@
+package com.lubycon.curriculum.subscribe.filter;
+
+import com.lubycon.curriculum.subscribe.exception.TypeFormSecretNotEquals;
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
+@Slf4j
+@WebFilter(urlPatterns = "/subscribe/typeform")
+public class TypeformFilter implements Filter {
+
+  @Value("${typeform.secret}")
+  private String secretKey;
+
+  @Override
+  public void doFilter(
+      final ServletRequest request, final ServletResponse response, final FilterChain chain)
+      throws IOException, ServletException {
+
+    final HttpServletRequest httpRequest = (HttpServletRequest) request;
+    final String typeFormSignatureValue = httpRequest.getHeader("Typeform-Signature");
+
+    if (!secretKey.equals(typeFormSignatureValue)) {
+      throw new TypeFormSecretNotEquals(typeFormSignatureValue);
+    }
+
+    chain.doFilter(request, response);
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/filter/TypeformFilter.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/filter/TypeformFilter.java
@@ -17,9 +17,9 @@ import org.springframework.beans.factory.annotation.Value;
 public class TypeformFilter implements Filter {
 
   @Value("${typeform.secret}")
-  private final String secretKey;
+  private String secretKey;
 
-  public TypeformFilter(final String secretKey) {
+  public void setSecretKey(final String secretKey) {
     this.secretKey = secretKey;
   }
 
@@ -31,7 +31,7 @@ public class TypeformFilter implements Filter {
     final HttpServletRequest httpRequest = (HttpServletRequest) request;
     final String typeFormSignatureValue = httpRequest.getHeader("Typeform-Signature");
 
-    if (!secretKey.equals(typeFormSignatureValue)) {
+    if (!typeFormSignatureValue.contains(secretKey)) {
       throw new TypeFormSecretNotEquals(typeFormSignatureValue);
     }
 

--- a/src/main/java/com/lubycon/curriculum/subscribe/repository/EmailRepository.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/repository/EmailRepository.java
@@ -1,0 +1,8 @@
+package com.lubycon.curriculum.subscribe.repository;
+
+import com.lubycon.curriculum.subscribe.domain.Email;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailRepository extends JpaRepository<Email, Long> {
+
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/service/SubscribeService.java
@@ -1,0 +1,18 @@
+package com.lubycon.curriculum.subscribe.service;
+
+import com.lubycon.curriculum.subscribe.domain.Email;
+import com.lubycon.curriculum.subscribe.repository.EmailRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SubscribeService {
+
+  private final EmailRepository emailRepository;
+
+  public void subscribe(final String email) {
+    emailRepository.save(new Email(email));
+  }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,5 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+typeform:
+  secret: local

--- a/src/test/java/com/lubycon/curriculum/base/ApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/base/ApiTest.java
@@ -42,8 +42,11 @@ public class ApiTest {
   }
 
   public void typeformFilterMockMvcSetUp() {
+    final TypeformFilter typeformFilter = new TypeformFilter();
+    typeformFilter.setSecretKey("local");
+
     this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
-        .addFilters(new TypeformFilter("local"))
+        .addFilters(typeformFilter)
         .addFilters(new CharacterEncodingFilter("UTF-8", true))
         .alwaysDo(print())
         .build();

--- a/src/test/java/com/lubycon/curriculum/base/ApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/base/ApiTest.java
@@ -3,6 +3,7 @@ package com.lubycon.curriculum.base;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lubycon.curriculum.subscribe.filter.TypeformFilter;
 import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +36,14 @@ public class ApiTest {
   @BeforeEach
   public void mockMvcSetUp() {
     this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .addFilters(new CharacterEncodingFilter("UTF-8", true))
+        .alwaysDo(print())
+        .build();
+  }
+
+  public void typeformFilterMockMvcSetUp() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .addFilters(new TypeformFilter("local"))
         .addFilters(new CharacterEncodingFilter("UTF-8", true))
         .alwaysDo(print())
         .build();

--- a/src/test/java/com/lubycon/curriculum/subscribe/api/SubScribeApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/subscribe/api/SubScribeApiTest.java
@@ -1,0 +1,88 @@
+package com.lubycon.curriculum.subscribe.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.lubycon.curriculum.base.ApiTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+class SubScribeApiTest extends ApiTest {
+
+  @DisplayName("Typeform 웹훅을 통해 이메일을 저장할 수 있다.")
+  @Test
+  public void typeformWebHookTest() throws Exception {
+    // given
+    final String url = "/subscribe/typeform";
+    final String email = "test@mail.com";
+    final String body = getRequestBody(email);
+
+    // when
+    final ResultActions resultActions = mockMvc.perform(post(url)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON)
+        .content(body));
+
+    // then
+    resultActions
+        .andExpect(status().isOk());
+  }
+
+
+  private String getRequestBody(final String email) {
+    return "{\n"
+        + "  \"event_type\": \"form_response\",\n"
+        + "  \"form_response\": {\n"
+        + "    \"landed_at\": \"2021-06-02T07:21:56Z\",\n"
+        + "    \"submitted_at\": \"2021-06-02T07:22:44Z\",\n"
+        + "    \"definition\": {\n"
+        + "      \"title\": \"Clelab  - 사전신청\",\n"
+        + "      \"fields\": [\n"
+        + "        {\n"
+        + "          \"title\": \"관심있는 주제\",\n"
+        + "          \"type\": \"multiple_choice\",\n"
+        + "          \"choices\": [\n"
+        + "            {\n"
+        + "              \"label\": \"HTML, CSS, JS\"\n"
+        + "            },\n"
+        + "            {\n"
+        + "              \"label\": \"SASS\"\n"
+        + "            }\n"
+        + "          ]\n"
+        + "        },\n"
+        + "        {\n"
+        + "          \"title\": \"메일 주소 응답!\",\n"
+        + "          \"type\": \"email\"\n"
+        + "        }\n"
+        + "      ]\n"
+        + "    },\n"
+        + "    \"answers\": [\n"
+        + "      {\n"
+        + "        \"type\": \"choices\",\n"
+        + "        \"choices\": {\n"
+        + "          \"labels\": [\n"
+        + "            \"HTML, CSS, JS\",\n"
+        + "            \"CSS\",\n"
+        + "            \"React\"\n"
+        + "          ]\n"
+        + "        },\n"
+        + "        \"field\": {\n"
+        + "          \"type\": \"multiple_choice\"\n"
+        + "        }\n"
+        + "      },\n"
+        + "      {\n"
+        + "        \"type\": \"email\",\n"
+        + "        \"email\": \"" + email + "\",\n"
+        + "        \"field\": {\n"
+        + "          \"type\": \"email\"\n"
+        + "        }\n"
+        + "      }\n"
+        + "    ]\n"
+        + "  }\n"
+        + "}";
+  }
+
+
+}

--- a/src/test/java/com/lubycon/curriculum/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/subscribe/service/SubscribeServiceTest.java
@@ -1,0 +1,36 @@
+package com.lubycon.curriculum.subscribe.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lubycon.curriculum.subscribe.domain.Email;
+import com.lubycon.curriculum.subscribe.repository.EmailRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class SubscribeServiceTest {
+
+  @Autowired
+  SubscribeService subscribeService;
+
+  @Autowired
+  EmailRepository emailRepository;
+
+  @DisplayName("이메일로 구독을 할 수 있다.")
+  @Test
+  public void getSectionTest() {
+    // when
+    final String email = "test@email.com";
+    subscribeService.subscribe(email);
+
+    // then
+    final List<Email> emails = emailRepository.findAll();
+    assertThat(emails.get(0).getEmail()).isEqualTo(email);
+  }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,3 +8,5 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+typeform:
+  secret: local


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->
구독을 받기 위해 사용하고 있는 Typeform의 응답을 기존에는 슬랙 웹훅와 연동해서 사용했는데,
무료 평가판이 종료되며 슬랙 웹훅을 사용하지 못하게 되어 서버에 이메일 구독용 API를 추가했습니다.


## 특별히 봐줬으면 하는 부분
필터를 테스트하지 않았더니 JaCoCo에 걸려 필터 테스트 코드를 부랴부랴 추가했는데, 필터를 테스트 해본 경험이 없어서 제대로 짠건지를 모르겠네요 ... 혹시 아시는 분이 계시다면 조언 부탁드립니다!

저는 아래와 같은 방식으로 구현했습니다.
1. MockMvc의 `addFilters()`를 사용하여 필터 추가
-> 이렇게 하고 실행을 하니, yml 파일에 설정해둔 외부 설정값을 읽기 전에 필터에 걸리게 되어, `@Value` 어노테이션이 제대로 동작하지 않고 null이 들어가는 이슈가 발생했습니다. 이를 해결하기 위해 필터에 set 메서드를 추가함으로서 해결했는데, 이게 맞는 방법인지는 모르겠네요 😭
2. 필터가 추가되어야 하는 테스트 메서드에 1번 동작을 하는 메서드 추가

<!-- 셀프 코멘트도 달아주세요! -->

## 참고 사항

resolved #60

<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
