### PR TITLE
chore: 서버 타임존 KST로 변경

### DIFF
--- a/.ebextensions/00-makeFiles.config
+++ b/.ebextensions/00-makeFiles.config
@@ -1,3 +1,6 @@
+commands:
+  set_time_zone:
+    command: ln -f -s /usr/share/zoneinfo/Asia/Seoul /etc/localtime
 files:
     "/sbin/appstart" :
         mode: "000755"

--- a/src/main/java/com/lubycon/curriculum/subscribe/service/TestSubscribeScheduler.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/service/TestSubscribeScheduler.java
@@ -14,7 +14,7 @@ public class TestSubscribeScheduler {
   private final EmailTesterService emailTesterService;
 
   @Transactional
-  @Scheduled(cron = "0 0 14 * * SUN")
+  @Scheduled(cron = "0 0 23 * * SUN")
   public void sendEmailToTester() {
     log.info(">>>> Scheduled Start ...");
     emailTesterService.sendToTesters();


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

기존에 서버가 타임존을 UTC를 사용했었는데, 스케줄러에 설정된 시간을 UTC 기준으로 계산하는 비용을 줄이기 위해 KST로 변경했습니다.


## 참고 사항
간단한 설정 변경이라 바로 머지하겠습니다.

resolved #90 
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
