### PR TITLE
구독 취소 api

### DIFF
--- a/src/main/java/com/lubycon/curriculum/subscribe/api/SubScribeApi.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/api/SubScribeApi.java
@@ -10,7 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +47,10 @@ public class SubScribeApi {
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(response);
+  }
+
+  @GetMapping("/subscribe/cancel/{email}/{id}")
+  public void cancelSubscribe(@PathVariable final String email, @PathVariable final Long id) {
+    subscribeService.cancelSubscribe(email, id);
   }
 }

--- a/src/main/java/com/lubycon/curriculum/subscribe/repository/EmailRepository.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/repository/EmailRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface EmailRepository extends JpaRepository<Email, Long> {
 
   boolean existsByEmail(String email);
+
+  Email findByEmail(String email);
 }

--- a/src/main/java/com/lubycon/curriculum/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/service/SubscribeService.java
@@ -17,4 +17,12 @@ public class SubscribeService {
     return new SubscribeResponse(savedEmail);
   }
 
+  public void cancelSubscribe(final String email, final Long id) {
+    final Email findEmail = emailRepository.findByEmail(email);
+
+    if (findEmail.getId().equals(id)) {
+      emailRepository.delete(findEmail);
+    }
+  }
+
 }

--- a/src/test/java/com/lubycon/curriculum/subscribe/api/SubScribeApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/subscribe/api/SubScribeApiTest.java
@@ -1,6 +1,7 @@
 package com.lubycon.curriculum.subscribe.api;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -186,5 +187,21 @@ class SubScribeApiTest extends ApiTest {
         + "}";
   }
 
+  @Sql("/make-email.sql")
+  @DisplayName("구독 신청 취소가 가능하다.")
+  @Test
+  public void cancelSubscribeTest() throws Exception {
+    // given
+    final String email = "exist@email.com";
+    final String id = "1";
 
+    final String url = "/subscribe/cancel/" + email + "/" + id;
+
+    // when
+    final ResultActions resultActions = mockMvc.perform(get(url));
+
+    // then
+    resultActions
+        .andExpect(status().isOk());
+  }
 }

--- a/src/test/java/com/lubycon/curriculum/subscribe/service/SubscribeServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/subscribe/service/SubscribeServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
@@ -32,5 +33,24 @@ class SubscribeServiceTest {
     final List<Email> emails = emailRepository.findAll();
     assertThat(emails.get(0).getEmail()).isEqualTo(email);
   }
+
+  @Sql("/make-email.sql")
+  @DisplayName("이메일로 구독 취소를 할 수 있다.")
+  @Test
+  public void cancelSubscribeTest() {
+    // given
+    final List<Email> beforeEmails = emailRepository.findAll();
+    assertThat(beforeEmails.size()).isGreaterThanOrEqualTo(1);
+
+    // when
+    final String email = "exist@email.com";
+    final Long id = 1L;
+    subscribeService.cancelSubscribe(email, id);
+
+    // then
+    final List<Email> afterEmails = emailRepository.findAll();
+    assertThat(afterEmails.size()).isZero();
+  }
+
 
 }


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

사용자는 구독취소를 할 때 메일을 보내지 않고 API를 통해 구독취소를 할 수 있다.


## 참고 사항

resolved #106 

<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
