### PR TITLE
구독 취소 시 얼럿 띄우게 처리

### DIFF
--- a/src/main/java/com/lubycon/curriculum/base/error/ErrorCode.java
+++ b/src/main/java/com/lubycon/curriculum/base/error/ErrorCode.java
@@ -19,7 +19,9 @@ public enum ErrorCode {
   FAILED_SEND_MAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S002", "Send mail failed : "),
   SES_SECRET_NOT_EQUALS(HttpStatus.UNAUTHORIZED, "S003", "SES secret not equals : "),
   EMAIL_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "S004", "EmailTemplate Not Found"),
-  CONFLICT_EMAIL(HttpStatus.CONFLICT, "S005", "이미 구독 신청하고 있는 이메일입니다.");
+  CONFLICT_EMAIL(HttpStatus.CONFLICT, "S005", "이미 구독 신청하고 있는 이메일입니다."),
+  FAILED_CANCEL_SUBSCRIBE(HttpStatus.BAD_REQUEST, "S006",
+      "해지에 실패했습니다. 관리자(admin@clelab.io)에게 문의해주세요.");
 
 
   private final String code;

--- a/src/main/java/com/lubycon/curriculum/base/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/lubycon/curriculum/base/error/GlobalExceptionHandler.java
@@ -1,6 +1,10 @@
 package com.lubycon.curriculum.base.error;
 
+import static com.lubycon.curriculum.base.util.HtmlResponseUtil.alertAndMove;
+
 import com.lubycon.curriculum.base.error.exception.BusinessException;
+import com.lubycon.curriculum.base.error.exception.HtmlBusinessException;
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -53,6 +57,14 @@ public class GlobalExceptionHandler {
     final ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
     final ErrorResponse response = ErrorResponse.of(errorCode);
     return new ResponseEntity<>(response, errorCode.getStatus());
+  }
+
+  @ExceptionHandler(HtmlBusinessException.class)
+  protected void htmlBusinessException(final BusinessException e) throws IOException {
+    log.error("HtmlBusinessException", e);
+    final ErrorCode errorCode = e.getErrorCode();
+
+    alertAndMove(errorCode.getMessage(), "https://clelab.io");
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/main/java/com/lubycon/curriculum/base/error/exception/HtmlBusinessException.java
+++ b/src/main/java/com/lubycon/curriculum/base/error/exception/HtmlBusinessException.java
@@ -1,0 +1,11 @@
+package com.lubycon.curriculum.base.error.exception;
+
+import com.lubycon.curriculum.base.error.ErrorCode;
+
+public class HtmlBusinessException extends BusinessException {
+
+  public HtmlBusinessException(final ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+}

--- a/src/main/java/com/lubycon/curriculum/base/util/HtmlResponseUtil.java
+++ b/src/main/java/com/lubycon/curriculum/base/util/HtmlResponseUtil.java
@@ -1,0 +1,25 @@
+package com.lubycon.curriculum.base.util;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class HtmlResponseUtil {
+
+  private HtmlResponseUtil() {
+  }
+
+  public static void alertAndMove(final String message, final String url)
+      throws IOException {
+    final HttpServletResponse response = ((ServletRequestAttributes) RequestContextHolder
+        .getRequestAttributes()).getResponse();
+
+    response.setContentType("text/html; charset=UTF-8");
+    final PrintWriter out = response.getWriter();
+    out.println("<script>alert('" + message + "'); "
+        + "location.replace('" + url + "');</script>");
+    out.flush();
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/api/SubScribeApi.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/api/SubScribeApi.java
@@ -5,6 +5,9 @@ import com.lubycon.curriculum.subscribe.dto.SubscribeResponse;
 import com.lubycon.curriculum.subscribe.dto.TypeformSubscribeRequest;
 import com.lubycon.curriculum.subscribe.service.SubscribeService;
 import com.lubycon.curriculum.subscribe.validation.SubscribeValidator;
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -50,7 +53,13 @@ public class SubScribeApi {
   }
 
   @GetMapping("/subscribe/cancel/{email}/{id}")
-  public void cancelSubscribe(@PathVariable final String email, @PathVariable final Long id) {
+  public void cancelSubscribe(@PathVariable final String email, @PathVariable final Long id,
+      final HttpServletResponse response) throws IOException {
     subscribeService.cancelSubscribe(email, id);
+
+    response.setContentType("text/html; charset=UTF-8");
+    final PrintWriter out = response.getWriter();
+    out.println("<script>alert('구독이 해지되었습니다.'); location.replace('https://clelab.io');</script>");
+    out.flush();
   }
 }

--- a/src/main/java/com/lubycon/curriculum/subscribe/api/SubScribeApi.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/api/SubScribeApi.java
@@ -1,12 +1,13 @@
 package com.lubycon.curriculum.subscribe.api;
 
+import static com.lubycon.curriculum.base.util.HtmlResponseUtil.alertAndMove;
+
 import com.lubycon.curriculum.subscribe.dto.SubscribeRequest;
 import com.lubycon.curriculum.subscribe.dto.SubscribeResponse;
 import com.lubycon.curriculum.subscribe.dto.TypeformSubscribeRequest;
 import com.lubycon.curriculum.subscribe.service.SubscribeService;
 import com.lubycon.curriculum.subscribe.validation.SubscribeValidator;
 import java.io.IOException;
-import java.io.PrintWriter;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -56,10 +57,7 @@ public class SubScribeApi {
   public void cancelSubscribe(@PathVariable final String email, @PathVariable final Long id,
       final HttpServletResponse response) throws IOException {
     subscribeService.cancelSubscribe(email, id);
+    alertAndMove("구독이 해지되었습니다.", "https://clelab.io");
 
-    response.setContentType("text/html; charset=UTF-8");
-    final PrintWriter out = response.getWriter();
-    out.println("<script>alert('구독이 해지되었습니다.'); location.replace('https://clelab.io');</script>");
-    out.flush();
   }
 }

--- a/src/main/java/com/lubycon/curriculum/subscribe/exception/EmailTemplateNotFoundException.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/exception/EmailTemplateNotFoundException.java
@@ -3,9 +3,9 @@ package com.lubycon.curriculum.subscribe.exception;
 import com.lubycon.curriculum.base.error.ErrorCode;
 import com.lubycon.curriculum.base.error.exception.EntityNotFoundException;
 
-public class EmailTemplateNotFound extends EntityNotFoundException {
+public class EmailTemplateNotFoundException extends EntityNotFoundException {
 
-  public EmailTemplateNotFound() {
+  public EmailTemplateNotFoundException() {
     super(ErrorCode.EMAIL_TEMPLATE_NOT_FOUND.getMessage());
   }
 }

--- a/src/main/java/com/lubycon/curriculum/subscribe/exception/FailedCancelSubscribeException.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/exception/FailedCancelSubscribeException.java
@@ -1,0 +1,11 @@
+package com.lubycon.curriculum.subscribe.exception;
+
+import com.lubycon.curriculum.base.error.ErrorCode;
+import com.lubycon.curriculum.base.error.exception.BusinessException;
+
+public class FailedCancelSubscribeException extends BusinessException {
+
+  public FailedCancelSubscribeException() {
+    super(ErrorCode.FAILED_CANCEL_SUBSCRIBE);
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/subscribe/exception/FailedCancelSubscribeException.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/exception/FailedCancelSubscribeException.java
@@ -1,9 +1,9 @@
 package com.lubycon.curriculum.subscribe.exception;
 
 import com.lubycon.curriculum.base.error.ErrorCode;
-import com.lubycon.curriculum.base.error.exception.BusinessException;
+import com.lubycon.curriculum.base.error.exception.HtmlBusinessException;
 
-public class FailedCancelSubscribeException extends BusinessException {
+public class FailedCancelSubscribeException extends HtmlBusinessException {
 
   public FailedCancelSubscribeException() {
     super(ErrorCode.FAILED_CANCEL_SUBSCRIBE);

--- a/src/main/java/com/lubycon/curriculum/subscribe/service/EmailTemplateService.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/service/EmailTemplateService.java
@@ -1,7 +1,7 @@
 package com.lubycon.curriculum.subscribe.service;
 
 import com.lubycon.curriculum.subscribe.domain.EmailTemplate;
-import com.lubycon.curriculum.subscribe.exception.EmailTemplateNotFound;
+import com.lubycon.curriculum.subscribe.exception.EmailTemplateNotFoundException;
 import com.lubycon.curriculum.subscribe.repository.EmailTemplateRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,12 +14,12 @@ public class EmailTemplateService {
 
   public EmailTemplate getEmailTemplate() {
     return emailTemplateRepository.findFirstByOrderByCreatedAtDesc()
-        .orElseThrow(EmailTemplateNotFound::new);
+        .orElseThrow(EmailTemplateNotFoundException::new);
   }
 
   public EmailTemplate getEmailTemplateById(final long id) {
     return emailTemplateRepository.findById(id)
-        .orElseThrow(EmailTemplateNotFound::new);
+        .orElseThrow(EmailTemplateNotFoundException::new);
   }
 
 }

--- a/src/main/java/com/lubycon/curriculum/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/lubycon/curriculum/subscribe/service/SubscribeService.java
@@ -2,6 +2,7 @@ package com.lubycon.curriculum.subscribe.service;
 
 import com.lubycon.curriculum.subscribe.domain.Email;
 import com.lubycon.curriculum.subscribe.dto.SubscribeResponse;
+import com.lubycon.curriculum.subscribe.exception.FailedCancelSubscribeException;
 import com.lubycon.curriculum.subscribe.repository.EmailRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,8 +21,13 @@ public class SubscribeService {
   public void cancelSubscribe(final String email, final Long id) {
     final Email findEmail = emailRepository.findByEmail(email);
 
-    if (findEmail.getId().equals(id)) {
-      emailRepository.delete(findEmail);
+    idMustBeSame(id, findEmail);
+    emailRepository.delete(findEmail);
+  }
+
+  private void idMustBeSame(final Long id, final Email findEmail) {
+    if (findEmail == null || !findEmail.getId().equals(id)) {
+      throw new FailedCancelSubscribeException();
     }
   }
 


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

기존에는 구독 취소 시 빈 페이지가 나왔지만, 구독 취소 시 alert을 띄우고 클랩팀 페이지로 리다이렉트 시키게 변경했습니다.

## 참고 사항
resolved #108 
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
