### PR TITLE
fix: 인트로 API에 썸네일 필드 추가

### DIFF
--- a/src/main/java/com/lubycon/curriculum/curriculum/dto/v2/CurriculumSectionsResponseV2.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/dto/v2/CurriculumSectionsResponseV2.java
@@ -14,6 +14,9 @@ import org.jetbrains.annotations.NotNull;
 public class CurriculumSectionsResponseV2 {
 
   @NotNull
+  private final String thumbnail;
+
+  @NotNull
   private final CurriculumInfoResponse curriculum;
 
   @NotNull
@@ -24,10 +27,12 @@ public class CurriculumSectionsResponseV2 {
 
 
   @Builder
-  public CurriculumSectionsResponseV2(
+  private CurriculumSectionsResponseV2(
+      @NotNull final String thumbnail,
       @NotNull final CurriculumInfoResponse curriculum,
       @NotNull final IntroResponseV2 intro,
       @NotNull final List<SectionTitlesResponse> sections) {
+    this.thumbnail = thumbnail;
     this.curriculum = curriculum;
     this.intro = intro;
     this.sections = sections;
@@ -37,6 +42,7 @@ public class CurriculumSectionsResponseV2 {
     final List<Section> sections = curriculum.getSections();
 
     return CurriculumSectionsResponseV2.builder()
+        .thumbnail(curriculum.getThumbnail())
         .intro(new IntroResponseV2(curriculum.getIntroSection()))
         .curriculum(new CurriculumInfoResponse(curriculum.getId(), curriculum.getTitle()))
         .sections(sections.stream()


### PR DESCRIPTION
## 내용
링크 공유 시 썸네일 미리보기를 띄워주기 위해 인트로 API에 썸네일 필드를 추가했습니다.
<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

## 참고 사항
resolved #115
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
