### PR TITLE
fix: cors clelab domain 추가

### DIFF
--- a/src/main/java/com/lubycon/curriculum/base/config/WebConfig.java
+++ b/src/main/java/com/lubycon/curriculum/base/config/WebConfig.java
@@ -11,6 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
   public void addCorsMappings(final CorsRegistry registry) {
     registry.addMapping("/**")
         .allowedOrigins("http://localhost:8080", "http://localhost:3000", "https://clelab.io",
-            "https://qa.clelab.io", "https://*.clelab.io");
+            "https://qa.clelab.io", "https://*.clelab.io", "https://www.clelab.io/",
+            "https://www.qa.clelab.io/");
   }
 }


### PR DESCRIPTION
## 내용
간헐적으로 발생하는 cors preflight 에러를 해결하기 위해 cors origin을 허용한다.



## 참고 사항

resolved #140 